### PR TITLE
Fix cart toggle behavior and improve icons

### DIFF
--- a/service.cart/component.php
+++ b/service.cart/component.php
@@ -18,9 +18,10 @@ $hi = HLBT::getById($HL_ROLES)->fetch();
 $e  = HLBT::compileEntity($hi);
 $res = $e->getDataClass()::getList(['select' => ['ID', 'UF_NAME', 'UF_RATE']]);
 while ($r = $res->fetch()) {
+    $rate = str_replace([' ', ','], ['', '.'], (string)$r['UF_RATE']);
     $rolesById[$r['ID']] = [
         'NAME' => $r['UF_NAME'],
-        'RATE' => (float)$r['UF_RATE']
+        'RATE' => (float)$rate
     ];
 }
 

--- a/service.cart/templates/.default/script.js
+++ b/service.cart/templates/.default/script.js
@@ -14,12 +14,21 @@ if (window.__SERVICE_CART_JS__) {
       const t = e.target.closest('.svc-toggle');
       if (t) {
         const card = t.closest('.svc-card');
+
+        if (currentOpenCard && currentOpenCard !== card) {
+          currentOpenCard.classList.remove('open');
+          const prevBtn = currentOpenCard.querySelector('.svc-toggle');
+          if (prevBtn) prevBtn.textContent = 'Читать подробнее';
+        }
+
         const body = card.querySelector('.svc-body');
         const open = card.classList.toggle('open');
         t.textContent = open ? 'Скрыть ▲' : 'Читать подробнее';
+        currentOpenCard = open ? card : null;
+
+        const detailBox = document.getElementById('detail-box');
 
         if (open) {
-          const detailBox = document.getElementById('detail-box');
           const serviceName = card.querySelector('.svc-name').textContent;
           const stageName = card.querySelector('.svc-tag').textContent;
           const bodyClone = body.cloneNode(true);
@@ -42,7 +51,7 @@ if (window.__SERVICE_CART_JS__) {
             detailBox.appendChild(table);
           }
         } else {
-          document.getElementById('detail-box').innerHTML = '<p class="hint">Выберите «Читать подробнее» слева</p>';
+          detailBox.innerHTML = '<p class="hint">Выберите «Читать подробнее» слева</p>';
         }
       }
 

--- a/service.catalog/templates/.default/script.js
+++ b/service.catalog/templates/.default/script.js
@@ -35,7 +35,7 @@ if (window.__SERVICE_CATALOG_JS__) {
         d.classList.remove('is-visible');
         d.previousElementSibling?.classList.remove('sr-open');
         const b = d.previousElementSibling?.querySelector('.sr-toggle');
-        if (b) b.textContent = 'Раскрыть ▼';
+        if (b) b.textContent = 'Раскрыть ˅';
       });
 
       rows.forEach(r => {
@@ -93,7 +93,7 @@ if (window.__SERVICE_CATALOG_JS__) {
         if (det) {
           const vis = det.classList.toggle('is-visible');
           row.classList.toggle('sr-open', vis);
-          tog.textContent = vis ? 'Скрыть ▲' : 'Раскрыть ▼';
+          tog.textContent = vis ? 'Скрыть ˄' : 'Раскрыть ˅';
           if (vis) det.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         }
         return;
@@ -116,7 +116,7 @@ if (window.__SERVICE_CATALOG_JS__) {
           if (ok) {
             btn.classList.toggle('sr-add', !add);
             btn.classList.toggle('sr-added', add);
-            btn.textContent = add ? 'Добавлено' : 'Добавить';
+            btn.textContent = add ? '✓ Добавлено' : 'Добавить';
             updSum(total);
           } else {
             alert('Сервер вернул некорректный ответ');

--- a/service.catalog/templates/.default/template.php
+++ b/service.catalog/templates/.default/template.php
@@ -59,15 +59,15 @@ $inCart = $_SESSION['SERVICE_CART'] ?? [];
             <div class="sr-btns">
               <?php if ($svc['IS_REQUIRED']): ?>
                 <button class="sr-status sr-required" disabled>
-                  Обязательно
+                  🔒 Обязательно
                 </button>
               <?php else: ?>
                 <button class="sr-status <?= $inCartFlg ? 'sr-added' : 'sr-add' ?>"
                         data-id="<?= $id ?>">
-                  <?= $inCartFlg ? 'Добавлено' : 'Добавить' ?>
+                  <?= $inCartFlg ? '✓ Добавлено' : 'Добавить' ?>
                 </button>
               <?php endif; ?>
-              <button class="sr-toggle">Раскрыть ▼</button>
+              <button class="sr-toggle">Раскрыть ˅</button>
             </div>
             <span class="sr-name"><?= htmlspecialcharsbx($svc['NAME']) ?></span>
             <span class="sr-tag"><?= htmlspecialcharsbx($sec['NAME']) ?></span>


### PR DESCRIPTION
## Summary
- close previous service details when opening a new one in cart
- correctly parse role rates from HL block
- add lock/check icons and subtle chevrons in catalog

## Testing
- `php -l service.cart/component.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858fb3fcf30832e8e2f72f1e43ada49